### PR TITLE
Use compinit -u to fix insecure directory warning

### DIFF
--- a/zsh/completion.zsh
+++ b/zsh/completion.zsh
@@ -1,5 +1,5 @@
 # Initialize zsh completion system
-autoload -Uz compinit && compinit
+autoload -Uz compinit && compinit -u
 
 # Git alias completion — tells zsh which git subcommand each alias wraps
 compdef _git gc=git-checkout


### PR DESCRIPTION
## Summary
- Use `compinit -u` instead of `compinit` to skip zsh's insecure directory security check
- Fixes the "zsh compinit: insecure directories" prompt on every new shell caused by Homebrew's group-write permissions on `/opt/homebrew/share/zsh`
- `-u` is safe on a single-user machine and is the permanent fix (unlike `chmod` which Homebrew can reset)

## Test plan
- [ ] Open a new zsh shell and verify no compinit warning appears
- [ ] Verify tab completion still works for git aliases (`gs<tab>`, `gc<tab>`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)