### PR TITLE
Fix nvm node resolution so pnpm/yarn/corepack work

### DIFF
--- a/myzshrc
+++ b/myzshrc
@@ -11,6 +11,10 @@ case $(uname -s) in
     ;;
 esac
 
+# Put nvm's default node ahead of Homebrew's node (added by osx.zsh above), so
+# node/npm/npx/pnpm/yarn/corepack all come from the same nvm-managed version.
+prepend_default_node_to_path
+
 . $ZD/aliases.zsh
 
 # Load gcloud completions before compinit to avoid double initialization

--- a/zsh/all_platforms.zsh
+++ b/zsh/all_platforms.zsh
@@ -29,18 +29,36 @@ if [[ -f $HOME/.bash/api_keys.sh ]]; then
   . $HOME/.bash/api_keys.sh
 fi
 
-# Lazy-load nvm (loading eagerly adds ~500ms to shell startup)
+# nvm: keep shell startup fast (sourcing nvm.sh eagerly adds ~500ms).
+# prepend_default_node_to_path puts the default node version's real bin/ on
+# PATH, so node, npm, npx, pnpm, yarn and corepack all resolve without ever
+# sourcing nvm. It's called from .myzshrc *after* the platform files so it wins
+# over Homebrew's node. nvm itself stays lazy; it's only needed to *switch*
+# node versions.
 export NVM_DIR="$HOME/.nvm"
+
+prepend_default_node_to_path() {
+    [ -s "$NVM_DIR/nvm.sh" ] || return
+    # Resolve the default alias to a concrete version dir. The alias usually
+    # holds "node" or "lts/*" (meaning "latest"), which isn't itself a dir, so
+    # fall back to the highest installed version (zsh-native version sort).
+    local ver
+    local -a dirs
+    ver=$([ -r "$NVM_DIR/alias/default" ] && cat "$NVM_DIR/alias/default")
+    if [ -z "$ver" ] || [ ! -d "$NVM_DIR/versions/node/$ver/bin" ]; then
+        dirs=( "$NVM_DIR"/versions/node/*(/N:t) )
+        ver=${${(On)dirs}[1]}
+    fi
+    [ -n "$ver" ] && [ -d "$NVM_DIR/versions/node/$ver/bin" ] &&
+        PATH="$NVM_DIR/versions/node/$ver/bin:$PATH"
+}
+
+# nvm stays lazy: source it only when `nvm` is actually invoked.
 if [ -s "$NVM_DIR/nvm.sh" ]; then
-    # Add node to PATH without loading nvm fully
-    [ -s "$NVM_DIR/alias/default" ] && PATH="$NVM_DIR/versions/node/$(cat $NVM_DIR/alias/default)/bin:$PATH"
-    lazy_nvm() {
-        unset -f nvm node npm npx
+    nvm() {
+        unset -f nvm
         . "$NVM_DIR/nvm.sh"
         [ -s "$NVM_DIR/bash_completion" ] && . "$NVM_DIR/bash_completion"
+        nvm "$@"
     }
-    nvm() { lazy_nvm; nvm "$@"; }
-    node() { lazy_nvm; node "$@"; }
-    npm() { lazy_nvm; npm "$@"; }
-    npx() { lazy_nvm; npx "$@"; }
 fi


### PR DESCRIPTION
## Problem

Claude Code (and the interactive shell) couldn't find `pnpm`. Root cause was two bugs in the nvm setup in `zsh/all_platforms.zsh`:

1. **Broken PATH line.** `versions/node/$(cat $NVM_DIR/alias/default)/bin` expanded to `versions/node/node/bin` — a nonexistent dir, because the `default` alias literally contains the word `node` (nvm's "latest" alias). So nvm's node `bin/` was **never** on PATH. `node`/`npm`/`npx` only worked via wrapper *functions*; `pnpm`/`yarn`/`corepack` had no wrappers and were invisible to the shell and to Claude.
2. **Homebrew shadowing.** Even with the bin on PATH, `osx.zsh` runs afterward and prepends Homebrew's bin, so `node`/`npm` silently resolved to an **incidental Homebrew node** (pulled in as a dependency of `sentry-wizard`), while `pnpm` came from nvm — a version skew.

## Fix

- Replace the broken line + `node`/`npm`/`npx` wrapper functions with `prepend_default_node_to_path()`, which resolves the `default` alias to a real version dir (falling back to the highest installed version via a dependency-free zsh-native version sort) and prepends its `bin/`.
- Call it from `.myzshrc` **after** the platform files so nvm's node wins over Homebrew's.
- `nvm` itself stays lazy — sourced only when `nvm` is actually invoked, so startup stays fast.

## Verification (fresh shell, full startup chain)

| tool | resolves to | version |
|------|-------------|---------|
| node / npm / npx / pnpm / yarn / corepack | all → `~/.nvm/.../v22.21.1/bin` | node v22.21.1, npm 10.9.4, pnpm 9.15.9 |

- `nvm` still lazy-loads and works (`nvm --version` → 0.39.1).
- Shell startup: **0.12s** (no regression).
- No more version skew — every tool comes from one nvm-managed version.

> Note: takes effect for Claude Code after a session restart (the shell snapshot is captured at session start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)