### PR TITLE
Add Android SDK tools to PATH

### DIFF
--- a/myzshrc
+++ b/myzshrc
@@ -28,3 +28,6 @@ export PATH="$HOME/.local/bin:$PATH"
 
 alias blaude="CLAUDE_CONFIG_DIR=~/.claude-bacio claude --dangerously-skip-permissions"
 eval "$(direnv hook zsh)"
+
+export ANDROID_HOME=$HOME/Library/Android/sdk
+export PATH="$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator:$ANDROID_HOME/cmdline-tools/latest/bin:$PATH"


### PR DESCRIPTION
Export `ANDROID_HOME` and add the Android SDK `platform-tools`, `emulator`, and `cmdline-tools/latest/bin` to PATH for Android development.

- `~/Library/Android/sdk` is present on the machine.
- `zsh -n myzshrc` passes (no syntax errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)